### PR TITLE
Expose default port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,6 @@ RUN chmod +x /sbin/nginx-boot && \
     apk --update add nginx bash && \
     rm -fR /var/cache/apk/*
 
+EXPOSE 80
+
 CMD [ "/sbin/nginx-boot" ]


### PR DESCRIPTION
This will make the image compatible with tools like [jwilder/nginx-proxy](https://github.com/jwilder/nginx-proxy) and [JrCs/docker-letsencrypt-nginx-proxy-companion](https://github.com/JrCs/docker-letsencrypt-nginx-proxy-companion).

The above popular tools orchestrate other docker containers by reading their ENV variables on start and stop. The containers with no exposed ports are skipped.

Currently, the only possible workaround is in adding `-p 80` explicitly. This has an unwanted side-effect – the port is mapped to some random port on host, which is not desired.
